### PR TITLE
fixed production type for boiler-mk2, boiler-mk3, heat-exchanger-mk2,…

### DIFF
--- a/prototypes/entity/entity-generators.lua
+++ b/prototypes/entity/entity-generators.lua
@@ -678,8 +678,7 @@ data:extend({
         {type = "input-output", position = {-2, 0.5}},
         {type = "input-output", position = {2, 0.5}}
       },
-      production_type = "input-output",
-      filter = "steam"
+      production_type = "input-output"
     },
     output_fluid_box =
     {
@@ -691,7 +690,8 @@ data:extend({
       {
         {type = "output", position = {0, -1.5}}
       },
-      production_type = "output"
+      production_type = "output",
+      filter = "steam"
     },
 	fluid_input =
     {

--- a/prototypes/entity/entity-generators.lua
+++ b/prototypes/entity/entity-generators.lua
@@ -678,7 +678,8 @@ data:extend({
         {type = "input-output", position = {-2, 0.5}},
         {type = "input-output", position = {2, 0.5}}
       },
-      production_type = "input-output"
+      production_type = "input-output",
+      filter = "steam"
     },
     output_fluid_box =
     {
@@ -1142,7 +1143,8 @@ data:extend({
       {
         {type = "output", position = {0, -1.5}}
       },
-      production_type = "output"
+      production_type = "output",
+      filter = "steam"
     },
 	fluid_input =
     {
@@ -1595,7 +1597,8 @@ data:extend({
       {
         {type = "output", position = {0, -1.5}}
       },
-      production_type = "output"
+      production_type = "output",
+      filter = "steam"
     },
     fluid_input =
     {
@@ -1863,7 +1866,8 @@ data:extend({
       {
         {type = "output", position = {0, -1.5}}
       },
-      production_type = "output"
+      production_type = "output",
+      filter = "steam"
     },
     fluid_input =
     {


### PR DESCRIPTION
Added production type filter for boilers and heat exchangers. Without filter these boilers produce water.
Changes tested on Factorio 0.16 and 0.3.1 mod version.